### PR TITLE
Add boost query feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ Here is an example configuration (in `solrconfig.xml`):
       <str name="filename">${solr.solr.home}/${solr.core.name}/conf/segmenter/projects.txt</str>
       <bool name="useLatLon">false</bool>
     </lst>
+    <lst name="suffix">
+      <str name="field">suffix</str>
+      <str name="dictionary">com.sematext.querysegmenter.SynonymSegmentDictionaryMemImpl</str>
+      <str name="filename">./solr/collection1/conf/segmenter/suffix.txt</str>
+      <bool name="useLatLon">false</bool>
+      <bool name="useBoostQuery">true</bool>
+    </lst>
   </lst>
 </searchComponent>
   
@@ -252,6 +259,9 @@ http://localhost:8080/solr/test/qs?q=solr
 
 For example, if *“solr”* is in the dictionary of projects (i.e. in the `projects.txt` file), the query will be rewritten to *“project:solr”*.
 
+Add a feature to support using boost query instead of filter. One of the use case is when searching person's name with suffix, the default behavior is to expect the name with suffix match to be boosted with higher relevancy instead of only showing the suffix matches.
+
+For example, if searching for *"John Smith Jr"*, when ```useBoostQuery``` is set to true in the segmenter configuration, the query will be rewritten to ```bq=suffix:Jr```.
 
 ### CentroidComponent
 

--- a/solr/solr/collection1/conf/schema.xml
+++ b/solr/solr/collection1/conf/schema.xml
@@ -106,6 +106,9 @@
    <field name="type_level2" type="string" indexed="true" stored="true"/>
    <field name="project" type="string" indexed="true" stored="true"/>
    <field name="city" type="string" indexed="true" stored="true"/>
+   <field name="name" type="text_en" indexed="true" stored="true"/>
+   <field name="suffix" type="string" indexed="true" stored="true"/>
+
    <!--secondary project name-->
    <field name="project_sec" type="string" indexed="true" stored="true"/>
    <!-- signature field, used for deduplication -->

--- a/solr/solr/collection1/conf/segmenter/suffix.txt
+++ b/solr/solr/collection1/conf/segmenter/suffix.txt
@@ -1,0 +1,3 @@
+Jr
+Sr
+III

--- a/solr/solr/collection1/conf/solrconfig.xml
+++ b/solr/solr/collection1/conf/solrconfig.xml
@@ -1514,13 +1514,20 @@
           <str name="dictionary">com.sematext.querysegmenter.geolocation.AreaSegmentDictionaryMemImpl</str>
           <str name="filename">./solr/collection1/conf/segmenter/neighborhood.txt</str>
           <bool name="useLatLon">true</bool>
-       </lst>
+      </lst>
       <lst name="city">
           <str name="field">city</str>
           <str name="dictionary">com.sematext.querysegmenter.GenericSegmentDictionaryMemImpl</str>
           <str name="filename">./solr/collection1/conf/segmenter/city.txt</str>
           <bool name="useLatLon">false</bool>
-       </lst>
+      </lst>
+      <lst name="suffix">
+        <str name="field">suffix</str>
+        <str name="dictionary">com.sematext.querysegmenter.SynonymSegmentDictionaryMemImpl</str>
+        <str name="filename">./solr/collection1/conf/segmenter/suffix.txt</str>
+        <bool name="useLatLon">false</bool>
+        <bool name="useBoostQuery">true</bool>
+      </lst>
     </lst>
   </searchComponent>
   
@@ -1534,7 +1541,18 @@
           <str>segmenter</str>
       </arr>
   </requestHandler>
-  
+
+  <requestHandler name="dismax_qs_bq" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="qf">name</str>
+      <!-- Other dismax params... -->
+    </lst>
+    <arr name="first-components">
+      <str>segmenter</str>
+    </arr>
+  </requestHandler>
+
   <queryParser name="segmenter_qparser"
     class="com.sematext.querysegmenter.solr.QuerySegmenterQParserPlugin">
     <lst name="segments">
@@ -1561,16 +1579,31 @@
           <str name="dictionary">com.sematext.querysegmenter.geolocation.AreaSegmentDictionaryMemImpl</str>
           <str name="filename">./solr/collection1/conf/segmenter/neighborhood.txt</str>
           <bool name="useLatLon">true</bool>
-       </lst>
+      </lst>
       <lst name="city">
           <str name="field">city</str>
           <str name="dictionary">com.sematext.querysegmenter.SynonymSegmentDictionaryMemImpl</str>
           <str name="filename">./solr/collection1/conf/segmenter/city.txt</str>
           <bool name="useLatLon">false</bool>
-       </lst>
+      </lst>
+      <lst name="suffix">
+        <str name="field">suffix</str>
+        <str name="dictionary">com.sematext.querysegmenter.SynonymSegmentDictionaryMemImpl</str>
+        <str name="filename">./solr/collection1/conf/segmenter/suffix.txt</str>
+        <bool name="useLatLon">false</bool>
+        <bool name="useBoostQuery">true</bool>
+      </lst>
     </lst>
   </queryParser>
   
+  <requestHandler name="dismax_bq_qparser" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="q">{!segmenter_qparser defType=edismax v=$qq}</str>
+      <str name="qf">name</str>
+    </lst>
+  </requestHandler>
+
   <requestHandler name="dismax_qparser" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">explicit</str>
@@ -1578,7 +1611,7 @@
       <str name="qf">title</str>
     </lst>
   </requestHandler>
-  
+
   <searchComponent name="centroidcomp"
      class="com.sematext.querysegmenter.solr.CentroidComponent">
     <str name="filename">./solr/collection1/conf/segmenter/centroid.csv</str>

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterComponent.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterComponent.java
@@ -75,7 +75,11 @@ public class QuerySegmenterComponent extends SearchComponent {
     for (TypedSegment typedSegment : typedSegments) {
       FieldMapping mapping = config.getMappings().get(typedSegment.getDictionaryName());
       String value = getValue(typedSegment, mapping);
-      q = q.replaceAll(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
+      if (mapping.useBoostQuery) {
+        q = q.replaceAll(typedSegment.getSegment(), String.format("&bq=%s:%s", mapping.field, value));
+      } else {
+        q = q.replaceAll(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
+      }
     }
 
     if (typedSegments.isEmpty()) {

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterComponent.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterComponent.java
@@ -9,6 +9,7 @@
 package com.sematext.querysegmenter.solr;
 
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
@@ -65,6 +66,7 @@ public class QuerySegmenterComponent extends SearchComponent {
 
     SolrParams params = rb.req.getParams();
     String q = params.get(CommonParams.Q);
+    String bq = null;
 
     if (q == null || q.isEmpty()) {
       return;
@@ -76,7 +78,8 @@ public class QuerySegmenterComponent extends SearchComponent {
       FieldMapping mapping = config.getMappings().get(typedSegment.getDictionaryName());
       String value = getValue(typedSegment, mapping);
       if (mapping.useBoostQuery) {
-        q = q.replaceAll(typedSegment.getSegment(), String.format("&bq=%s:%s", mapping.field, value));
+        q = q.replaceAll(typedSegment.getSegment(), "");
+        bq = String.format("%s:%s", mapping.field, value);
       } else {
         q = q.replaceAll(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
       }
@@ -89,6 +92,9 @@ public class QuerySegmenterComponent extends SearchComponent {
     // Override q for the "query" component.
     ModifiableSolrParams modifiableSolrParams = new ModifiableSolrParams(params);
     modifiableSolrParams.set(CommonParams.Q, q);
+    if (bq != null) {
+      modifiableSolrParams.set(DisMaxParams.BQ, bq);
+    }
     rb.req.setParams(modifiableSolrParams);
   }
 

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterConfig.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterConfig.java
@@ -23,6 +23,7 @@ public class QuerySegmenterConfig {
   private static final String INIT_ATTR_FILENAME = "filename";
   private static final String INIT_ATTR_FIELD = "field";
   private static final String INIT_ATTR_LATLON = "useLatLon";
+  private static final String INIT_ATTR_BQ = "useBoostQuery";
 
   private final QuerySegmenterDefaultImpl segmenter;
 
@@ -31,6 +32,8 @@ public class QuerySegmenterConfig {
     String field;
 
     boolean useLatLon;
+
+    boolean useBoostQuery;
 
   }
 
@@ -72,6 +75,7 @@ public class QuerySegmenterConfig {
     FieldMapping mapping = new FieldMapping();
     mapping.field = (String) values.get(INIT_ATTR_FIELD);
     mapping.useLatLon = (Boolean) values.get(INIT_ATTR_LATLON);
+    mapping.useBoostQuery = values.get(INIT_ATTR_BQ) == null ? false : (Boolean) values.get(INIT_ATTR_BQ);
     mappings.put(name, mapping);
   }
 

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
@@ -60,7 +60,11 @@ public class QuerySegmenterQParser extends QParser {
     for (TypedSegment typedSegment : typedSegments) {
       FieldMapping mapping = mappings.get(typedSegment.getDictionaryName());
       String value = QuerySegmenterComponent.getValue(typedSegment, mapping);
-      qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
+      if (mapping.useBoostQuery) {
+        qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("&bq=%s:%s", mapping.field, value));
+      } else {
+        qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
+      }
     }
 
     // Passing null allows to use another qparser defined with defType (like edismax)

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
@@ -8,12 +8,18 @@
  */
 package com.sematext.querysegmenter.solr;
 
+import org.apache.lucene.queries.function.BoostedQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SyntaxError;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,11 +63,15 @@ public class QuerySegmenterQParser extends QParser {
     String qstr = getString();
 
     List<TypedSegment> typedSegments = segmenter.segment(qstr);
+    List<Query> boostQueries = new ArrayList<>();
+
     for (TypedSegment typedSegment : typedSegments) {
       FieldMapping mapping = mappings.get(typedSegment.getDictionaryName());
       String value = QuerySegmenterComponent.getValue(typedSegment, mapping);
       if (mapping.useBoostQuery) {
-        qstr = qstr.replaceFirst(typedSegment.getSegment(), "").concat(String.format("&bq=%s:%s", mapping.field, value));
+        qstr = qstr.replaceFirst(typedSegment.getSegment(), "");
+        String qs = String.format("%s:%s", mapping.field, value);
+        boostQueries.add(subQuery(qs, null).getQuery());
       } else {
         qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
       }
@@ -70,6 +80,12 @@ public class QuerySegmenterQParser extends QParser {
     // Passing null allows to use another qparser defined with defType (like edismax)
     // See SOLR-2972
     QParser parser = subQuery(qstr, null);
-    return parser.parse();
+    BooleanQuery.Builder query = new BooleanQuery.Builder();
+    query.add(parser.parse(), BooleanClause.Occur.MUST);
+
+    for(Query bq:boostQueries) {
+      query.add(bq, BooleanClause.Occur.SHOULD);
+    }
+    return query.build();
   }
 }

--- a/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
+++ b/solr/src/main/java/com/sematext/querysegmenter/solr/QuerySegmenterQParser.java
@@ -61,7 +61,7 @@ public class QuerySegmenterQParser extends QParser {
       FieldMapping mapping = mappings.get(typedSegment.getDictionaryName());
       String value = QuerySegmenterComponent.getValue(typedSegment, mapping);
       if (mapping.useBoostQuery) {
-        qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("&bq=%s:%s", mapping.field, value));
+        qstr = qstr.replaceFirst(typedSegment.getSegment(), "").concat(String.format("&bq=%s:%s", mapping.field, value));
       } else {
         qstr = qstr.replaceFirst(typedSegment.getSegment(), String.format("%s:%s", mapping.field, value));
       }

--- a/solr/src/test/java/com/sematext/querysegmenter/solr/QuerySegmenterQParserTest.java
+++ b/solr/src/test/java/com/sematext/querysegmenter/solr/QuerySegmenterQParserTest.java
@@ -103,7 +103,7 @@ public class QuerySegmenterQParserTest extends AbstractSolrTestCase {
   }
 
   /**
-   * The query "John Smith Jr" should be rewritten to "John Smith &bq=suffix:Jr"
+   * The query "John Jr Smith" should be rewritten to "John Smith&bq=suffix:Jr"
    * The response should show three docs name contains John or Smith and the id=11 suffix=Jr will be the first doc as it has higher relevancy
    */
   @Test
@@ -111,7 +111,7 @@ public class QuerySegmenterQParserTest extends AbstractSolrTestCase {
 
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.add(CommonParams.QT, DISMAX_BQ_QPARSER);
-    params.add("qq", "John Smith Jr");
+    params.add("qq", "John Jr Smith");
 
     SolrQueryRequest req = request(params, DISMAX_BQ_QPARSER);
 

--- a/solr/src/test/java/com/sematext/querysegmenter/solr/QuerySegmenterQParserTest.java
+++ b/solr/src/test/java/com/sematext/querysegmenter/solr/QuerySegmenterQParserTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 public class QuerySegmenterQParserTest extends AbstractSolrTestCase {
 
   private static final String DISMAX_QPARSER = "dismax_qparser";
+  private static final String DISMAX_BQ_QPARSER = "dismax_bq_qparser";
 
   @Override
   public void setUp() throws Exception {
@@ -33,6 +34,11 @@ public class QuerySegmenterQParserTest extends AbstractSolrTestCase {
     assertU(adoc("id", "2", "project", "Tika", "type", "wiki", "title", "Solr can be used with Tika"));
     assertU(adoc("id", "3", "project", "Lucene", "type", "wiki", "title", "Locations are fun!", "location", "45.5,-93.5"));
     assertU(adoc("id", "4", "city", "new york"));
+
+    assertU(adoc("id", "11", "name", "John Smith", "suffix", "Jr", "title", "Solr is great!"));
+    assertU(adoc("id", "13", "name", "John Smith", "suffix", "Sr", "title", "Solr can be used with Tika"));
+    assertU(adoc("id", "12", "name", "Jon Doe", "suffix", "Jr"));
+    assertU(adoc("id", "14", "name", "John Doe"));
 
     assertU("commit", commit());
   }
@@ -96,9 +102,31 @@ public class QuerySegmenterQParserTest extends AbstractSolrTestCase {
         "//result[@name='response']/doc[1]/str[@name='id'][.='4']");
   }
 
+  /**
+   * The query "John Smith Jr" should be rewritten to "John Smith &bq=suffix:Jr"
+   * The response should show three docs name contains John or Smith and the id=11 suffix=Jr will be the first doc as it has higher relevancy
+   */
+  @Test
+  public void test_bq_with_request_handler() {
+
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.add(CommonParams.QT, DISMAX_BQ_QPARSER);
+    params.add("qq", "John Smith Jr");
+
+    SolrQueryRequest req = request(params, DISMAX_BQ_QPARSER);
+
+    assertQ(req, "//result[@name='response'][@numFound='3']",
+            "//result[@name='response']/doc[1]/str[@name='id'][.='11']",
+            "//result[@name='response']/doc[2]/str[@name='id'][.='13']");
+  }
+
   private SolrQueryRequest request(ModifiableSolrParams params) {
+    return request(params, DISMAX_QPARSER);
+  }
+
+  private SolrQueryRequest request(ModifiableSolrParams params, String handlerName) {
     SolrCore core = h.getCore();
-    SolrRequestHandler handler = core.getRequestHandler(DISMAX_QPARSER);
+    SolrRequestHandler handler = core.getRequestHandler(handlerName);
 
     SolrQueryResponse rsp = new SolrQueryResponse();
     NamedList<Object> list = new NamedList<Object>();


### PR DESCRIPTION
Set ```<bool name="useBoostQuery">true</bool>``` for the segmenter to activate bq rewritten:

```?q={!seg+defType=edismax}John+Smith+Jr``` will be converted to q=John+Smith&bq=suffix:Jr
